### PR TITLE
3 로그인 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	// implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/circle/circle_backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/circle/circle_backend/security/config/SecurityConfig.java
@@ -1,5 +1,12 @@
 package com.circle.circle_backend.security.config;
 
+import com.circle.circle_backend.security.filter.JwtAuthenticationFilter;
+import com.circle.circle_backend.security.filter.JwtAuthorizationFilter;
+import com.circle.circle_backend.security.service.UserDetailsServiceImpl;
+import com.circle.circle_backend.security.utils.JwtTokenUtils;
+import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -8,55 +15,70 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화
-                .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/api/users").permitAll() // `/api/users`는 인증 없이 접근 가능
-                        .requestMatchers("/api/login").permitAll() // `/api/login`도 인증 없이 접근 가능
-                        .anyRequest().authenticated() // 그 외의 모든 요청은 인증 필요
-                );
-
-        return http.build();
-    }
-
-
-    @Bean
-    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
-        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
-        authenticationProvider.setUserDetailsService(userDetailsService); // 사용자 인증에 필요한 UserDetailsService 설정
-        authenticationProvider.setPasswordEncoder(passwordEncoder); // 암호화된 비밀번호 확인을 위한 PasswordEncoder 설정
-
-        return new ProviderManager(authenticationProvider);
-    }
-
-
-    @Bean
-    public UserDetailsService userDetailsService() {
-        UserDetails userDetails = User.withDefaultPasswordEncoder()
-                .username("user")
-                .password("password")
-                .build();
-
-        return new InMemoryUserDetailsManager(userDetails);
-    }
+    private final JwtTokenUtils jwtTokenUtils;
+    private final UserDetailsServiceImpl userDetailsServiceImpl;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userDetailsServiceImpl);
+        authenticationProvider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(authenticationProvider);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenUtils);
+        filter.setAuthenticationManager(authenticationManager()); // AuthenticationManager 설정
+        filter.setFilterProcessesUrl("/api/login"); // 커스텀 로그인 URL 설정
+        return filter;
+    }
+
+    @Bean
+    public Filter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtTokenUtils, userDetailsServiceImpl);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 보호 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // 기본 설정인 SessionCreationPolicy을 사용하지 않고 JWT 사용하기 위함
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                // 요정 인증 설정
+                .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                        .requestMatchers("/api/users").permitAll() // `/api/users`는 인증 없이 접근 가능
+                        .requestMatchers("/api/login").permitAll() // `/api/login`는 인증 없이 접근 가능
+                        .anyRequest().authenticated() // 그 외의 모든 요청은 인증 필요
+                )
+                // 필터 순서 설정
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class) // 인증 필터 먼저 실행
+                .addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class)
+                ;
+
+        return http.build();
+    }
+
 
 }

--- a/src/main/java/com/circle/circle_backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/circle/circle_backend/security/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.circle.circle_backend.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화
+                .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers("/api/users").permitAll() // `/api/users`는 인증 없이 접근 가능
+                        .requestMatchers("/api/login").permitAll() // `/api/login`도 인증 없이 접근 가능
+                        .anyRequest().authenticated() // 그 외의 모든 요청은 인증 필요
+                );
+
+        return http.build();
+    }
+
+
+    @Bean
+    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userDetailsService); // 사용자 인증에 필요한 UserDetailsService 설정
+        authenticationProvider.setPasswordEncoder(passwordEncoder); // 암호화된 비밀번호 확인을 위한 PasswordEncoder 설정
+
+        return new ProviderManager(authenticationProvider);
+    }
+
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails userDetails = User.withDefaultPasswordEncoder()
+                .username("user")
+                .password("password")
+                .build();
+
+        return new InMemoryUserDetailsManager(userDetails);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/circle/circle_backend/security/constant/JwtTokenConstant.java
+++ b/src/main/java/com/circle/circle_backend/security/constant/JwtTokenConstant.java
@@ -1,0 +1,13 @@
+package com.circle.circle_backend.security.constant;
+
+public class JwtTokenConstant {
+    public static final String AUTH_ACCESS_HEADER = "Authorization";
+    public static final String AUTH_REFRESH_HEADER = "RefreshToken";
+
+    public static final String AUTHORIZATION_KEY = "auth";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    // Token 유효기간
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 60 * 60 * 1000L; // 1시간
+    public static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L; // 1주
+}

--- a/src/main/java/com/circle/circle_backend/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/circle/circle_backend/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,89 @@
+package com.circle.circle_backend.security.filter;
+
+import com.circle.circle_backend.security.filter.port.LoginRequest;
+import com.circle.circle_backend.security.utils.JwtTokenUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.ResponseCookie;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static com.circle.circle_backend.security.constant.JwtTokenConstant.*;
+
+@RequiredArgsConstructor
+@Slf4j(topic = "JwtAuthenticationFilter")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtTokenUtils jwtTokenUtils;
+
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            //json 형태의 String 데이터를 LoginRequest로 변환
+            LoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(),
+                    LoginRequest.class);
+
+            List<GrantedAuthority> authorities = Collections.singletonList(
+                    new SimpleGrantedAuthority("ROLE_USER"));
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginRequest.getEmail(),
+                            loginRequest.getPassword(),
+                            authorities
+                    )
+            );
+        } catch (IOException e) {
+            log.error("로그인 시도(attemptAuthentication) 예외 발생 {}", e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    // 로그인 성공시 처리
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authentication) throws IOException {
+        // accessToken, refreshToken 생성
+        String email = authentication.getName();
+        String accessToken = jwtTokenUtils.createAccessToken(email);
+        String refreshToken = jwtTokenUtils.createRefreshToken(email);
+
+        // 헤더에 accessToken 담기
+        response.addHeader(AUTH_ACCESS_HEADER, accessToken);
+
+        // HTTP-Only Secure Cookie로 Refresh Token 설정
+        ResponseCookie cookie = ResponseCookie.from(AUTH_REFRESH_HEADER, refreshToken)
+                .httpOnly(true) // JavaScript에서 접근 불가
+                .secure(true) // HTTPS에서만 전송
+                .maxAge(REFRESH_TOKEN_EXPIRE_TIME) // 유효기간 (7일)
+                .path("/") // 쿠키의 유효 경로
+                .sameSite("Strict") // SameSite 설정
+                .build();
+
+        // refreshToken을 쿠키로 응답에 추가
+        response.addHeader("Set-Cookie", cookie.toString());
+
+        // accessToken JSON 응답에 포함
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        // JSON 형식으로 accessToken 응답
+        response.getWriter().write(new ObjectMapper().writeValueAsString(Collections.singletonMap("accessToken", accessToken)));
+
+    }
+
+}
+

--- a/src/main/java/com/circle/circle_backend/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/circle/circle_backend/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,93 @@
+package com.circle.circle_backend.security.filter;
+
+import com.circle.circle_backend.security.utils.JwtTokenUtils;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.circle.circle_backend.security.constant.JwtTokenConstant.AUTH_ACCESS_HEADER;
+
+@RequiredArgsConstructor
+@Slf4j(topic = "JwtAuthorizationFilter")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenUtils jwtTokenUtils;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String requestUri = request.getRequestURI();
+
+        // 인증이 필요 없는 경로
+        if (requestUri.equals("/api/users") || requestUri.equals("/api/login")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = jwtTokenUtils.getAccessToken(request); // 헤더에서 AccessToken 가져오기
+
+        if (jwtTokenUtils.validateToken(accessToken)) {
+            log.info("유효한 accessToken");
+            authenticateWithAccessToken(accessToken);
+        } else {
+            log.info("유효하지 않은 accessToken");
+            Claims claims = jwtTokenUtils.parseClaims(accessToken);
+            createNewAccessTokenWithRefreshToken(request, response, claims.getSubject());
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // accessToken이 유효 - SecurityContextHolder에 인증 객체 끼우기
+    public void authenticateWithAccessToken(String token) {
+        Claims claims = jwtTokenUtils.parseClaims(token);
+        log.info("Access Token 인증 처리 시작: email={}", claims.getSubject());
+        Authentication authentication = createAuthentication(claims.getSubject());
+        SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContext에 인증 객체 설정
+        log.info("Access Token 인증 처리 완료");
+    }
+
+    // accessToken이 유효 - 인증 객체 생성
+    private Authentication createAuthentication(String email) {
+        log.info("인증 객체 생성 시작");
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        log.info("인증 객체 생성 성공");
+        return new UsernamePasswordAuthenticationToken(userDetails, "ROLE_USER", userDetails.getAuthorities());
+    }
+
+    // accessToken이 유효하지 않은 경우 - 리프레시 토큰 검증 및 엑세스토큰 재발급
+    public void createNewAccessTokenWithRefreshToken(HttpServletRequest request,
+                                                     HttpServletResponse response, String email) {
+        log.info("refreshToken 검증 시도");
+        String refreshToken = jwtTokenUtils.getRefreshToken(request);
+
+        // refreshToken이 유효한 토큰인지 확인
+        if (jwtTokenUtils.validateToken(refreshToken)) {
+            log.info("유효한 refreshToken");
+            // accessToken 다시 생성, 헤더에 전달
+            String newAccessToken = jwtTokenUtils.createAccessToken(email);
+            response.addHeader(AUTH_ACCESS_HEADER, newAccessToken);
+            authenticateWithAccessToken(newAccessToken);
+        } else {
+            log.warn("유효하지 않은 Refresh Token: email={}", email);
+            SecurityContextHolder.clearContext(); // 인증 정보 초기화
+        }
+    }
+
+}
+
+

--- a/src/main/java/com/circle/circle_backend/security/filter/port/LoginRequest.java
+++ b/src/main/java/com/circle/circle_backend/security/filter/port/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.circle.circle_backend.security.filter.port;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/circle/circle_backend/security/service/UserDetailsImpl.java
+++ b/src/main/java/com/circle/circle_backend/security/service/UserDetailsImpl.java
@@ -1,0 +1,56 @@
+package com.circle.circle_backend.security.service;
+
+import com.circle.circle_backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority("ROLE_USER");
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+
+}

--- a/src/main/java/com/circle/circle_backend/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/circle/circle_backend/security/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.circle.circle_backend.security.service;
+
+import com.circle.circle_backend.user.domain.User;
+import com.circle.circle_backend.user.service.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(email));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/circle/circle_backend/security/utils/JwtTokenUtils.java
+++ b/src/main/java/com/circle/circle_backend/security/utils/JwtTokenUtils.java
@@ -1,0 +1,105 @@
+package com.circle.circle_backend.security.utils;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Date;
+
+import static com.circle.circle_backend.security.constant.JwtTokenConstant.*;
+
+@Component
+@Slf4j(topic = "JwtUtil")
+public class JwtTokenUtils {
+
+    private final Key key;
+
+    public JwtTokenUtils(@Value("${jwt.secret.key}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // accessToken 생성
+    public String createAccessToken(String email) {
+        long now = (new Date()).getTime();
+
+        return BEARER_PREFIX + Jwts.builder()
+                .setSubject(email)
+                .claim(AUTHORIZATION_KEY, "ROLE_USER")
+                .setExpiration(new Date(now + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // refreshToken 생성
+    public String createRefreshToken(String email) {
+        long now = (new Date()).getTime();
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 헤더에서 accessToken 가져오기
+    public String getAccessToken(HttpServletRequest request) {
+        String token = request.getHeader(BEARER_PREFIX);
+        if (!(StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX))) {
+            return null;
+        }
+        return token.substring(BEARER_PREFIX.length());
+    }
+
+    public String getRefreshToken(HttpServletRequest request) {
+        // 요청에서 쿠키 배열 가져오기
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            // 특정 쿠키 이름(Refresh Token)에 해당하는 쿠키 검색
+            for (Cookie cookie : cookies) {
+                if (AUTH_REFRESH_HEADER.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        // 쿠키에서 Refresh Token이 없을 경우 null 반환
+        return null;
+    }
+
+    // 토큰 검증하기
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key) // 서명 검증에 사용할 키 설정
+                    .build()            // 파서 생성
+                    .parseClaimsJws(token); // 토큰 파싱 및 검증
+            return true; // 검증 성공
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e); // 서명 또는 형식 오류
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e); // 토큰 만료
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e); // 지원되지 않는 토큰
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e); // 토큰이 비어 있음
+        }
+        return false; // 검증 실패
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key) // 서명 검증에 사용할 키 설정
+                .build()            // 파서 생성
+                .parseClaimsJws(token) // JWT 파싱 및 서명 검증
+                .getBody();          // Claims 반환
+    }
+
+}

--- a/src/main/java/com/circle/circle_backend/security/utils/PasswordUtils.java
+++ b/src/main/java/com/circle/circle_backend/security/utils/PasswordUtils.java
@@ -1,0 +1,7 @@
+package com.circle.circle_backend.security.utils;
+
+public interface PasswordUtils {
+    String encode(String rawPassword);
+    boolean matches(String rawPassword, String encodedPassword);
+}
+

--- a/src/main/java/com/circle/circle_backend/security/utils/PasswordUtilsImpl.java
+++ b/src/main/java/com/circle/circle_backend/security/utils/PasswordUtilsImpl.java
@@ -1,0 +1,22 @@
+package com.circle.circle_backend.security.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordUtilsImpl implements PasswordUtils {
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public String encode(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/circle/circle_backend/security/utils/PasswordUtilsImpl.java
+++ b/src/main/java/com/circle/circle_backend/security/utils/PasswordUtilsImpl.java
@@ -1,10 +1,12 @@
 package com.circle.circle_backend.security.utils;
 
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
+@Builder
 @RequiredArgsConstructor
 public class PasswordUtilsImpl implements PasswordUtils {
 

--- a/src/main/java/com/circle/circle_backend/user/controller/UserCreateController.java
+++ b/src/main/java/com/circle/circle_backend/user/controller/UserCreateController.java
@@ -2,7 +2,6 @@ package com.circle.circle_backend.user.controller;
 
 import com.circle.circle_backend.user.domain.User;
 import com.circle.circle_backend.user.domain.UserCreateRequest;
-import com.circle.circle_backend.user.service.UserService;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/circle/circle_backend/user/controller/UserCreateController.java
+++ b/src/main/java/com/circle/circle_backend/user/controller/UserCreateController.java
@@ -1,7 +1,7 @@
 package com.circle.circle_backend.user.controller;
 
 import com.circle.circle_backend.user.domain.User;
-import com.circle.circle_backend.user.domain.UserCreateDto;
+import com.circle.circle_backend.user.domain.UserCreateRequest;
 import com.circle.circle_backend.user.service.UserService;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +21,8 @@ public class UserCreateController {
     private final UserService userService;
 
     @PostMapping
-    public ResponseEntity<UserResponse> create(@RequestBody UserCreateDto userCreateDto) {
-        User user = userService.create(userCreateDto);
+    public ResponseEntity<UserResponse> create(@RequestBody UserCreateRequest userCreateRequest) {
+        User user = userService.create(userCreateRequest);
         return ResponseEntity.
                 status(HttpStatus.CREATED)
                 .body(UserResponse.from(user));

--- a/src/main/java/com/circle/circle_backend/user/controller/UserService.java
+++ b/src/main/java/com/circle/circle_backend/user/controller/UserService.java
@@ -1,0 +1,9 @@
+package com.circle.circle_backend.user.controller;
+
+import com.circle.circle_backend.user.domain.User;
+import com.circle.circle_backend.user.domain.UserCreateRequest;
+
+public interface UserService {
+
+    User create(UserCreateRequest userCreateRequest);
+}

--- a/src/main/java/com/circle/circle_backend/user/domain/User.java
+++ b/src/main/java/com/circle/circle_backend/user/domain/User.java
@@ -1,6 +1,5 @@
 package com.circle.circle_backend.user.domain;
 
-import com.circle.circle_backend.security.service.PasswordUtils;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,12 +29,12 @@ public class User {
         this.profileImage = profileImage;
     }
 
-    public static User from(UserCreateRequest userCreateRequest) {
+    public static User from(UserCreateRequest userCreateRequest, String encodedPassword) {
         return User.builder()
                 .firstName(userCreateRequest.getFirstName())
                 .lastName(userCreateRequest.getLastName())
                 .email(userCreateRequest.getEmail())
-                .password(userCreateRequest.getPassword())
+                .password(encodedPassword)
                 .nickname(userCreateRequest.getNickname())
                 .build();
     }

--- a/src/main/java/com/circle/circle_backend/user/domain/User.java
+++ b/src/main/java/com/circle/circle_backend/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.circle.circle_backend.user.domain;
 
+import com.circle.circle_backend.security.service.PasswordUtils;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -29,14 +30,13 @@ public class User {
         this.profileImage = profileImage;
     }
 
-    // TODO: 비밀번호 암호화하여 저장
-    public static User from(UserCreateDto userCreateDto) {
+    public static User from(UserCreateRequest userCreateRequest) {
         return User.builder()
-                .firstName(userCreateDto.getFirstName())
-                .lastName(userCreateDto.getLastName())
-                .email(userCreateDto.getEmail())
-                .password(userCreateDto.getPassword())
-                .nickname(userCreateDto.getNickname())
+                .firstName(userCreateRequest.getFirstName())
+                .lastName(userCreateRequest.getLastName())
+                .email(userCreateRequest.getEmail())
+                .password(userCreateRequest.getPassword())
+                .nickname(userCreateRequest.getNickname())
                 .build();
     }
 

--- a/src/main/java/com/circle/circle_backend/user/domain/UserCreateRequest.java
+++ b/src/main/java/com/circle/circle_backend/user/domain/UserCreateRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class UserCreateDto {
+public class UserCreateRequest {
     private String firstName;
     private String lastName;
     private String nickname;

--- a/src/main/java/com/circle/circle_backend/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/com/circle/circle_backend/user/infrastructure/UserJpaRepository.java
@@ -3,6 +3,10 @@ package com.circle.circle_backend.user.infrastructure;
 import com.circle.circle_backend.user.infrastructure.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+    Optional<UserEntity> findByEmail(String email);
 
 }

--- a/src/main/java/com/circle/circle_backend/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/circle/circle_backend/user/infrastructure/UserRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.circle.circle_backend.user.service.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepository {
@@ -15,5 +17,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public User save(User user) {
         return userJpaRepository.save(UserEntity.from(user)).toUser();
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userJpaRepository.findByEmail(email).map(UserEntity::toUser);
     }
 }

--- a/src/main/java/com/circle/circle_backend/user/infrastructure/entity/UserEntity.java
+++ b/src/main/java/com/circle/circle_backend/user/infrastructure/entity/UserEntity.java
@@ -35,7 +35,6 @@ public class UserEntity {
 
     public static UserEntity from (User user) {
         UserEntity userEntity = new UserEntity();
-        userEntity.id = user.getId();
         userEntity.email = user.getEmail();
         userEntity.password = user.getPassword();
         userEntity.firstName = user.getFirstName();

--- a/src/main/java/com/circle/circle_backend/user/service/UserRepository.java
+++ b/src/main/java/com/circle/circle_backend/user/service/UserRepository.java
@@ -2,7 +2,12 @@ package com.circle.circle_backend.user.service;
 
 import com.circle.circle_backend.user.domain.User;
 
+import java.util.Optional;
+
 public interface UserRepository {
 
     User save(User user);
+
+    Optional<User> findByEmail(String email);
+
 }

--- a/src/main/java/com/circle/circle_backend/user/service/UserService.java
+++ b/src/main/java/com/circle/circle_backend/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.circle.circle_backend.user.service;
 
 import com.circle.circle_backend.user.domain.User;
-import com.circle.circle_backend.user.domain.UserCreateDto;
+import com.circle.circle_backend.user.domain.UserCreateRequest;
 import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +15,8 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public User create(UserCreateDto userCreateDto) {
-        User user = User.from(userCreateDto);
+    public User create(UserCreateRequest userCreateRequest) {
+        User user = User.from(userCreateRequest);
         user = userRepository.save(user);
         return user;
     }

--- a/src/main/java/com/circle/circle_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/circle/circle_backend/user/service/UserServiceImpl.java
@@ -1,20 +1,23 @@
 package com.circle.circle_backend.user.service;
 
+import com.circle.circle_backend.user.controller.UserService;
 import com.circle.circle_backend.user.domain.User;
 import com.circle.circle_backend.user.domain.UserCreateRequest;
 import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 @Builder
-public class UserService {
+public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 
+    @Override
     public User create(UserCreateRequest userCreateRequest) {
         User user = User.from(userCreateRequest);
         user = userRepository.save(user);

--- a/src/main/java/com/circle/circle_backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/circle/circle_backend/user/service/UserServiceImpl.java
@@ -1,12 +1,12 @@
 package com.circle.circle_backend.user.service;
 
+import com.circle.circle_backend.security.utils.PasswordUtils;
 import com.circle.circle_backend.user.controller.UserService;
 import com.circle.circle_backend.user.domain.User;
 import com.circle.circle_backend.user.domain.UserCreateRequest;
 import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,10 +16,12 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PasswordUtils passwordUtils;
 
     @Override
     public User create(UserCreateRequest userCreateRequest) {
-        User user = User.from(userCreateRequest);
+        String encodedPassword = passwordUtils.encode(userCreateRequest.getPassword());
+        User user = User.from(userCreateRequest, encodedPassword);
         user = userRepository.save(user);
         return user;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,7 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}

--- a/src/test/java/com/circle/circle_backend/CircleBackendApplicationTests.java
+++ b/src/test/java/com/circle/circle_backend/CircleBackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.circle.circle_backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CircleBackendApplicationTests {
 
 	@Test

--- a/src/test/java/com/circle/circle_backend/common/TestContainer.java
+++ b/src/test/java/com/circle/circle_backend/common/TestContainer.java
@@ -1,6 +1,8 @@
 package com.circle.circle_backend.common;
 
 import com.circle.circle_backend.user.controller.UserCreateController;
+import com.circle.circle_backend.user.controller.UserService;
+import com.circle.circle_backend.user.mock.FakePasswordUtils;
 import com.circle.circle_backend.user.mock.FakeUserRepository;
 import com.circle.circle_backend.user.service.UserRepository;
 import com.circle.circle_backend.user.service.UserServiceImpl;
@@ -9,15 +11,16 @@ public class TestContainer {
 
     public final UserCreateController userCreateController;
     public final UserRepository userRepository;
-    public final UserServiceImpl userServiceImpl;
+    public final UserService userService;
 
     public TestContainer() {
         this.userRepository = new FakeUserRepository();
-        this.userServiceImpl = UserServiceImpl.builder()
+        this.userService = UserServiceImpl.builder()
                 .userRepository(this.userRepository)
+                .passwordUtils(new FakePasswordUtils())
                 .build();
         this.userCreateController = UserCreateController.builder()
-                .userService(this.userServiceImpl)
+                .userService(this.userService)
                 .build();
     }
 }

--- a/src/test/java/com/circle/circle_backend/common/TestContainer.java
+++ b/src/test/java/com/circle/circle_backend/common/TestContainer.java
@@ -3,21 +3,21 @@ package com.circle.circle_backend.common;
 import com.circle.circle_backend.user.controller.UserCreateController;
 import com.circle.circle_backend.user.mock.FakeUserRepository;
 import com.circle.circle_backend.user.service.UserRepository;
-import com.circle.circle_backend.user.service.UserService;
+import com.circle.circle_backend.user.service.UserServiceImpl;
 
 public class TestContainer {
 
     public final UserCreateController userCreateController;
     public final UserRepository userRepository;
-    public final UserService userService;
+    public final UserServiceImpl userServiceImpl;
 
     public TestContainer() {
         this.userRepository = new FakeUserRepository();
-        this.userService = UserService.builder()
+        this.userServiceImpl = UserServiceImpl.builder()
                 .userRepository(this.userRepository)
                 .build();
         this.userCreateController = UserCreateController.builder()
-                .userService(this.userService)
+                .userService(this.userServiceImpl)
                 .build();
     }
 }

--- a/src/test/java/com/circle/circle_backend/user/controller/UserCreateControllerTest.java
+++ b/src/test/java/com/circle/circle_backend/user/controller/UserCreateControllerTest.java
@@ -1,7 +1,7 @@
 package com.circle.circle_backend.user.controller;
 
 import com.circle.circle_backend.common.TestContainer;
-import com.circle.circle_backend.user.domain.UserCreateDto;
+import com.circle.circle_backend.user.domain.UserCreateRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +14,7 @@ class UserCreateControllerTest {
     void 사용자는_회원가입을_할_수_있다() {
         // given
         TestContainer testContainer = new TestContainer();
-        UserCreateDto userCreateDto = UserCreateDto.builder()
+        UserCreateRequest userCreateRequest = UserCreateRequest.builder()
                 .email("test@email.com")
                 .password("password")
                 .firstName("Test")
@@ -23,12 +23,12 @@ class UserCreateControllerTest {
                 .build();
 
         // when
-        ResponseEntity<UserResponse> response= testContainer.userCreateController.create(userCreateDto);
+        ResponseEntity<UserResponse> response= testContainer.userCreateController.create(userCreateRequest);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(201));
-        assertThat(response.getBody().getEmail()).isEqualTo(userCreateDto.getEmail());
-        assertThat(response.getBody().getNickname()).isEqualTo(userCreateDto.getNickname());
+        assertThat(response.getBody().getEmail()).isEqualTo(userCreateRequest.getEmail());
+        assertThat(response.getBody().getNickname()).isEqualTo(userCreateRequest.getNickname());
 
     }
 

--- a/src/test/java/com/circle/circle_backend/user/domain/UserTest.java
+++ b/src/test/java/com/circle/circle_backend/user/domain/UserTest.java
@@ -1,10 +1,13 @@
 package com.circle.circle_backend.user.domain;
 
+import com.circle.circle_backend.user.mock.FakePasswordUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserTest {
+
+    private FakePasswordUtils fakePasswordUtils = new FakePasswordUtils();
 
     @Test
     public void User를_UserCreateDto로_생성할_수_있다() {
@@ -14,19 +17,19 @@ class UserTest {
                 .firstName("test")
                 .lastName("test")
                 .nickname("test")
-                .password("test")
+                .password("password")
                 .build();
 
         // when
-        User user = User.from(userCreateRequest);
+        String encodedPassword = fakePasswordUtils.encode(userCreateRequest.getPassword());
+        User user = User.from(userCreateRequest, encodedPassword);
 
         // then
         assertThat(user.getEmail()).isEqualTo("test@test.com");
         assertThat(user.getFirstName()).isEqualTo("test");
         assertThat(user.getLastName()).isEqualTo("test");
         assertThat(user.getNickname()).isEqualTo("test");
-        assertThat(user.getPassword()).isEqualTo("test");
+        assertThat(user.getPassword()).isEqualTo("encodedpassword");
     }
 
-    // TODO: 비밀번호 암호화하여 저장 테스트
 }

--- a/src/test/java/com/circle/circle_backend/user/domain/UserTest.java
+++ b/src/test/java/com/circle/circle_backend/user/domain/UserTest.java
@@ -9,7 +9,7 @@ class UserTest {
     @Test
     public void User를_UserCreateDto로_생성할_수_있다() {
         // given
-        UserCreateDto userCreateDto = UserCreateDto.builder()
+        UserCreateRequest userCreateRequest = UserCreateRequest.builder()
                 .email("test@test.com")
                 .firstName("test")
                 .lastName("test")
@@ -18,7 +18,7 @@ class UserTest {
                 .build();
 
         // when
-        User user = User.from(userCreateDto);
+        User user = User.from(userCreateRequest);
 
         // then
         assertThat(user.getEmail()).isEqualTo("test@test.com");

--- a/src/test/java/com/circle/circle_backend/user/mock/FakePasswordUtils.java
+++ b/src/test/java/com/circle/circle_backend/user/mock/FakePasswordUtils.java
@@ -1,0 +1,19 @@
+package com.circle.circle_backend.user.mock;
+
+import com.circle.circle_backend.security.utils.PasswordUtils;
+
+public class FakePasswordUtils implements PasswordUtils {
+
+    @Override
+    public String encode(String rawPassword) {
+        return "encoded" + rawPassword;
+    }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        if (encodedPassword.equals(encode(rawPassword))) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/circle/circle_backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/circle/circle_backend/user/service/UserServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.circle.circle_backend.user.service;
 
+import com.circle.circle_backend.common.TestContainer;
+import com.circle.circle_backend.user.controller.UserService;
 import com.circle.circle_backend.user.domain.User;
 import com.circle.circle_backend.user.domain.UserCreateRequest;
 import com.circle.circle_backend.user.mock.FakeUserRepository;
@@ -10,11 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class UserServiceImplTest {
 
-    private UserServiceImpl userServiceImpl;
+    private UserService userService;
 
     @BeforeEach
     void init() {
-        this.userServiceImpl = UserServiceImpl.builder()
+        this.userService = UserServiceImpl.builder()
                 .userRepository(new FakeUserRepository())
                 .build();
     }
@@ -22,6 +24,7 @@ class UserServiceImplTest {
     @Test
     void UserCreateDto로_유저를_생성할_수_있다() {
         // given
+        TestContainer testContainer = new TestContainer();
         UserCreateRequest userCreateRequest = UserCreateRequest.builder()
                 .email("test@email.com")
                 .password("password")
@@ -31,11 +34,11 @@ class UserServiceImplTest {
                 .build();
 
         // when
-        User user = userServiceImpl.create(userCreateRequest);
+        User user = testContainer.userService.create(userCreateRequest);
 
         // then
         assertThat(user.getEmail()).isEqualTo("test@email.com");
-        assertThat(user.getPassword()).isEqualTo("password");
+        assertThat(user.getPassword()).isEqualTo("encodedpassword");
         assertThat(user.getFirstName()).isEqualTo("Test");
         assertThat(user.getLastName()).isEqualTo("Test");
         assertThat(user.getNickname()).isEqualTo("Test");

--- a/src/test/java/com/circle/circle_backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/circle/circle_backend/user/service/UserServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.circle.circle_backend.user.service;
 
-import com.circle.circle_backend.security.service.PasswordUtils;
 import com.circle.circle_backend.user.domain.User;
 import com.circle.circle_backend.user.domain.UserCreateRequest;
 import com.circle.circle_backend.user.mock.FakeUserRepository;
@@ -9,13 +8,13 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class UserServiceTest {
+class UserServiceImplTest {
 
-    private UserService userService;
+    private UserServiceImpl userServiceImpl;
 
     @BeforeEach
     void init() {
-        this.userService = UserService.builder()
+        this.userServiceImpl = UserServiceImpl.builder()
                 .userRepository(new FakeUserRepository())
                 .build();
     }
@@ -32,7 +31,7 @@ class UserServiceTest {
                 .build();
 
         // when
-        User user = userService.create(userCreateRequest);
+        User user = userServiceImpl.create(userCreateRequest);
 
         // then
         assertThat(user.getEmail()).isEqualTo("test@email.com");

--- a/src/test/java/com/circle/circle_backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/circle/circle_backend/user/service/UserServiceTest.java
@@ -1,7 +1,8 @@
 package com.circle.circle_backend.user.service;
 
+import com.circle.circle_backend.security.service.PasswordUtils;
 import com.circle.circle_backend.user.domain.User;
-import com.circle.circle_backend.user.domain.UserCreateDto;
+import com.circle.circle_backend.user.domain.UserCreateRequest;
 import com.circle.circle_backend.user.mock.FakeUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ class UserServiceTest {
     @Test
     void UserCreateDto로_유저를_생성할_수_있다() {
         // given
-        UserCreateDto userCreateDto = UserCreateDto.builder()
+        UserCreateRequest userCreateRequest = UserCreateRequest.builder()
                 .email("test@email.com")
                 .password("password")
                 .firstName("Test")
@@ -31,7 +32,7 @@ class UserServiceTest {
                 .build();
 
         // when
-        User user = userService.create(userCreateDto);
+        User user = userService.create(userCreateRequest);
 
         // then
         assertThat(user.getEmail()).isEqualTo("test@email.com");

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true


### PR DESCRIPTION
## 🔘Part

- [ ] FE
- [x] BE

  <br/>

## 🔎 작업 내용

- jwt, security 의존성 추가
- 인증, 인가 custom filter 개발
- AccessToken은 헤더에, RefreshToken은 헤더 set-cookie로 전달
- 추가적으로 userEntity에서 user의 아이디를 가져오는 버그도 수정

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/b48f2141-1d32-443e-b870-bb2f33ee054e)
로그인 시 헤더에 Accesstoken과 RefreshToken이 잘 전달됨을 확인


<br/>

## 🔧 앞으로의 과제

- Cors 필터 개발 필요
- 모든 요청이 필터를 거치는 문제 해결
- userRole 세분화시 하드코딩 수정

  <br/>

## ➕ 이슈 링크

- [circle_backend #3]https://github.com/circle-kr/circle_backend/issues/3

<br/>